### PR TITLE
Execute the SafariViewManager on the main thread

### DIFF
--- a/SafariViewManager.m
+++ b/SafariViewManager.m
@@ -8,6 +8,11 @@
 
 RCT_EXPORT_MODULE()
 
+- (dispatch_queue_t)methodQueue
+{
+  return dispatch_get_main_queue();
+}
+
 RCT_EXPORT_METHOD(show:(NSDictionary *)args callback:(RCTResponseSenderBlock)callback)
 {
 


### PR DESCRIPTION
If the SafariView is triggered while the keyboard is active, the following exception is thrown:

`[UIKeyboardTaskQueue waitUntilAllTasksAreFinished] may only be called from the main thread.`

This is similar to https://github.com/facebook/react-native/pull/4231, which was resolved by https://github.com/cizhaoyang/react-native/commit/6dd171b8c2b412e79b4b92b2e2cc75486658e283.

This pull request forces the SafariViewManager to run on the main thread. See https://facebook.github.io/react-native/docs/native-modules-ios.html#threading for more details.