### PR TITLE
Fixes that RCTNativeAppEventEmitter was not found and a redbox was shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The following events are fired by the Safari View.
 ### onShow
 __Example__
 ```js
-let showSubscription = SafariView.addEventListener(''
+let showSubscription = SafariView.addEventListener(
   "onShow",
   () => {
     StatusBarIOS.setStyle("light-content");

--- a/README.md
+++ b/README.md
@@ -112,22 +112,22 @@ SafariView.isAvailable()
 ## Events
 The following events are fired by the Safari View.
 
-### SafariViewOnShow
+### onShow
 __Example__
 ```js
-let showSubscription = NativeAppEventEmitter.addListener(
-  "SafariViewOnShow",
+let showSubscription = SafariView.addEventListener(''
+  "onShow",
   () => {
     StatusBarIOS.setStyle("light-content");
   }
 );
 ```
 
-### SafariViewOnDismiss
+### onDismiss
 __Example__
 ```js
-let dismissSubscription = NativeAppEventEmitter.addListener(
-  "SafariViewOnDismiss",
+let dismissSubscription = SafariView.addEventListener(
+  "onDismiss",
   () => {
     StatusBarIOS.setStyle("default");
   }

--- a/SafariViewManager.m
+++ b/SafariViewManager.m
@@ -38,7 +38,7 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args callback:(RCTResponseSenderBlock)cal
     UIViewController *ctrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
     [ctrl presentViewController:self.safariView animated:YES completion:nil];
 
-    [self.bridge.eventDispatcher sendAppEventWithName:@"SafariViewOnShow" body:nil];
+    [self.bridge.eventDispatcher sendDeviceEventWithName:@"SafariViewOnShow" body:nil];
 }
 
 RCT_EXPORT_METHOD(isAvailable:(RCTResponseSenderBlock)callback)

--- a/examples/SafariViewExample/index.ios.js
+++ b/examples/SafariViewExample/index.ios.js
@@ -3,7 +3,6 @@ import React, {
   AlertIOS,
   AppRegistry,
   Component,
-  NativeAppEventEmitter,
   processColor,
   StatusBarIOS,
   StyleSheet,
@@ -16,26 +15,21 @@ import SafariView from 'react-native-safari-view';
 
 class SafariViewExample extends Component {
   componentDidMount() {
-    this.showSubscription = NativeAppEventEmitter.addListener(
-      'SafariViewShow', () => {
-        console.log("SafariViewShow")
-
-        StatusBarIOS.setStyle("light-content");
-      }
-    );
-
-    this.dismissSubscription = NativeAppEventEmitter.addListener(
-      'SafariViewDismiss', () => {
-        console.log("SafariViewDismiss");
-
-        StatusBarIOS.setStyle("default");
-      }
-    );
+    this.showSubscription = () => {
+      console.log("SafariView onShow")
+      StatusBarIOS.setStyle("light-content");
+    };
+    this.dismissSubscription = () => {
+      console.log("SafariView onDismiss");
+      StatusBarIOS.setStyle("default");
+    };
+    SafariView.addEventListener("onShow", this.showSubscription);
+    SafariView.addEventListener("onDismiss", this.dismissSubscription);
   }
 
   componentWillUnmount() {
-    this.showSubscription.remove();
-    this.dismissSubscription.remove();
+    SafariView.removeEventListener("onShow", this.showSubscription);
+    SafariView.removeEventListener("onDismiss", this.dismissSubscription);
   }
 
   render() {

--- a/index.ios.js
+++ b/index.ios.js
@@ -52,7 +52,7 @@ var SafariViewManager = {
   addEventListener(event, listener) {
     if (event === 'onShow') {
       DeviceEventEmitter.addListener('SafariViewOnShow', listener);
-    } else if (event == 'onDismiss') {
+    } else if (event === 'onDismiss') {
       NativeAppEventEmitter.addListener('SafariViewOnDismiss', listener);
     }
   },
@@ -60,7 +60,7 @@ var SafariViewManager = {
   removeEventListener(event, listener) {
     if (event === 'onShow') {
       DeviceEventEmitter.removeListener('SafariViewOnShow', listener);
-    } else if (event == 'onDismiss') {
+    } else if (event === 'onDismiss') {
       NativeAppEventEmitter.removeListener('SafariViewOnDismiss', listener);
     }
   }

--- a/index.ios.js
+++ b/index.ios.js
@@ -6,6 +6,8 @@
 
 const {
   NativeModules,
+  NativeAppEventEmitter,
+  DeviceEventEmitter,
   processColor
 } = require('react-native');
 const NativeSafariViewManager = NativeModules.SafariViewManager;
@@ -45,6 +47,22 @@ var SafariViewManager = {
         resolve(true);
       });
     });
+  },
+
+  addEventListener(event, listener) {
+    if (event === 'onShow') {
+      DeviceEventEmitter.addListener('SafariViewOnShow', listener);
+    } else if (event == 'onDismiss') {
+      NativeAppEventEmitter.addListener('SafariViewOnDismiss', listener);
+    }
+  },
+
+  removeEventListener(event, listener) {
+    if (event === 'onShow') {
+      DeviceEventEmitter.removeListener('SafariViewOnShow', listener);
+    } else if (event == 'onDismiss') {
+      NativeAppEventEmitter.removeListener('SafariViewOnDismiss', listener);
+    }
   }
 };
 


### PR DESCRIPTION
Fixes that RCTNativeAppEventEmitter was not found and a redbox was shown when the safari webview was opened.

This fixes #13 and was a similar fix to #17 -- but with changing only one event emitter and wrap the different event listener classes in SafariView.js both events still work.

This makes the API also more robust for upcoming changes under the hood.

A new npm release would be great. Thanks for sharing the safari-view.

---
EDIT by @naoufal: Closes #13, closes #17