### PR TITLE
return the listener so we can remove it

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -51,9 +51,9 @@ var SafariViewManager = {
 
   addEventListener(event, listener) {
     if (event === 'onShow') {
-      DeviceEventEmitter.addListener('SafariViewOnShow', listener);
+      return DeviceEventEmitter.addListener('SafariViewOnShow', listener);
     } else if (event === 'onDismiss') {
-      NativeAppEventEmitter.addListener('SafariViewOnDismiss', listener);
+      return NativeAppEventEmitter.addListener('SafariViewOnDismiss', listener);
     }
   },
 


### PR DESCRIPTION
The PR submitted #25 keeps track of listener which you aren't responsible. all you need to provide is the listener result so we can keep a reference to it and remove it as needed. 