### PR TITLE
Fix Android crashes

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -9,8 +9,6 @@ const {NativeModules} = require('react-native');
 const NativeSafariViewManager = NativeModules.SafariViewManager;
 
 var SafariViewManager = {
-  test: function() {
-  },
   isAvailable: function() {
     return new Promise(function(resolve, reject) {
       NativeSafariViewManager.isAvailable(function(error) {

--- a/index.android.js
+++ b/index.android.js
@@ -5,13 +5,11 @@
  */
 'use strict';
 
-var warning = require('warning');
 const {NativeModules} = require('react-native');
 const NativeSafariViewManager = NativeModules.SafariViewManager;
 
 var SafariViewManager = {
   test: function() {
-    warning('Not yet implemented for Android.');
   },
   isAvailable: function() {
     return new Promise(function(resolve, reject) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-safari-view",
   "version": "1.0.1",
   "description": "A React Native wrapper for Safari View Controller",
-  "main": "index.ios.js",
+  "main": "index",
   "scripts": {
     "lint": "node_modules/.bin/eslint .",
     "test": "npm run lint"


### PR DESCRIPTION
- Changes entry point to `index` so Android version doesn’t
crash on launch for release builds
- Removes warning that caused error due to a missing dependency