### PR TITLE
Subclass RCTEventEmitter instead of using global eventDispatcher.

### DIFF
--- a/SafariViewManager.h
+++ b/SafariViewManager.h
@@ -1,9 +1,11 @@
 #import "RCTBridgeModule.h"
+#import "RCTEventEmitter.h"
 
 @import SafariServices;
 
-@interface SafariViewManager : NSObject <RCTBridgeModule, SFSafariViewControllerDelegate>
+@interface SafariViewManager : RCTEventEmitter <RCTBridgeModule, SFSafariViewControllerDelegate>
 
 @property (nonatomic) SFSafariViewController *safariView;
+@property bool hasListeners;
 
 @end

--- a/SafariViewManager.m
+++ b/SafariViewManager.m
@@ -2,10 +2,8 @@
 #import "RCTUtils.h"
 #import "RCTLog.h"
 #import "RCTConvert.h"
-#import "RCTEventDispatcher.h"
 
 @implementation SafariViewManager
-@synthesize bridge = _bridge;
 
 RCT_EXPORT_MODULE()
 
@@ -38,7 +36,9 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args callback:(RCTResponseSenderBlock)cal
     UIViewController *ctrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
     [ctrl presentViewController:self.safariView animated:YES completion:nil];
 
-    [self.bridge.eventDispatcher sendDeviceEventWithName:@"SafariViewOnShow" body:nil];
+    if (self.hasListeners) {
+        [self sendEventWithName:@"onShow" body:nil];
+    }
 }
 
 RCT_EXPORT_METHOD(isAvailable:(RCTResponseSenderBlock)callback)
@@ -56,12 +56,26 @@ RCT_EXPORT_METHOD(dismiss)
     [self safariViewControllerDidFinish:self.safariView];
 }
 
+-(void)startObserving {
+    self.hasListeners = YES;
+}
+
+-(void)stopObserving {
+    self.hasListeners = NO;
+}
+
+-(NSArray<NSString *> *)supportedEvents {
+    return @[@"onShow",@"onDismiss"];
+}
+
 -(void)safariViewControllerDidFinish:(nonnull SFSafariViewController *)controller
 {
     [controller dismissViewControllerAnimated:true completion:nil];
     NSLog(@"[SafariView] SafariView dismissed.");
 
-    [self.bridge.eventDispatcher sendAppEventWithName:@"SafariViewOnDismiss" body:nil];
+    if (self.hasListeners) {
+        [self sendEventWithName:@"onDismiss" body:nil];
+    }
 }
 
 @end

--- a/index.ios.js
+++ b/index.ios.js
@@ -4,11 +4,11 @@
 'use strict';
 import {
   NativeModules,
-  NativeAppEventEmitter,
-  DeviceEventEmitter,
+  NativeEventEmitter,
   processColor
 } from 'react-native';
 const NativeSafariViewManager = NativeModules.SafariViewManager;
+const moduleEventEmitter = new NativeEventEmitter(NativeSafariViewManager);
 
 /**
  * High-level docs for the SafariViewManager iOS API can be written here.
@@ -48,18 +48,10 @@ export default {
   },
 
   addEventListener(event, listener) {
-    if (event === 'onShow') {
-      return DeviceEventEmitter.addListener('SafariViewOnShow', listener);
-    } else if (event === 'onDismiss') {
-      return NativeAppEventEmitter.addListener('SafariViewOnDismiss', listener);
-    }
+    return moduleEventEmitter.addListener(event, listener);
   },
 
   removeEventListener(event, listener) {
-    if (event === 'onShow') {
-      DeviceEventEmitter.removeListener('SafariViewOnShow', listener);
-    } else if (event === 'onDismiss') {
-      NativeAppEventEmitter.removeListener('SafariViewOnDismiss', listener);
-    }
+    moduleEventEmitter.removeListener(event, listener);
   }
 };


### PR DESCRIPTION
Just a bit of housekeeping - calling `bridge.eventDispatcher.sendAppEventWithName` has been [deprecated](https://github.com/facebook/react-native/commit/d9737571c43d39af41d539de2dd12c2ceb5cda0e) since 0.28. The advice is to subclass `RCTEventEmitter` instead, which has the advantage of making the events module-scoped.

NB: This will break clients which rely on the now-removed global `SafariViewOnShow` / `SafariViewOnDismiss` events, but those events aren't documented anyway.
