### PR TITLE
Add index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+const SafariView = require('./index');
+
+module.exports = SafariView;


### PR DESCRIPTION
It seems that *.ios and *.android suffixes confuse some JavaScript infrastructure tools like Jest or ESLint. I looked over a few other modules like (react-native-svg, react-native-vector-icons, react-native-maps, etc.), they have root platform-independent file. 
Do you use react-native-safari-view with Jest and ESLint? Have you managed to avoid `module not found` problem?