### PR TITLE
Fix tintColor in iOS 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,13 @@ class YourComponent extends Component {
 Displays a Safari View with the provided url.
 
 __Arguments__
-- `safariOptions` - An `Object` containing a `url` key and optionally a `readerMode` key and/or a `tintColor`.
+- `safariOptions` - An `Object` containing a `url` key and optionally a `readerMode` key, a `tintColor`, and/or a `barTintColor`.
 
 __safariOptions__
 - `url` - A `String` containing the url you want to load in the Safari View
 - `readerMode` - A `Boolean` indicating to use Safari's Reader Mode if available
-- `tintColor` - A `String` containing a hex, rgba or rgba color
+- `tintColor` - A `String` containing a hex, rgba or rgba color to use for the browser controls
+- `barTintColor` - A `String` containing a hex, rgba or rgba color to use for the background of the browser controls (only available on iOS 10 and higher)
 
 __Examples__
 ```js
@@ -92,6 +93,7 @@ SafariView.show({
   url: "http://facebook.github.io/react/blog/2015/03/26/introducing-react-native.html",
   readerMode: true // optional,
   tintColor: "#000" // optional
+  barTintColor: "#fff" // optional
 });
 ```
 

--- a/SafariViewManager.m
+++ b/SafariViewManager.m
@@ -1,3 +1,4 @@
+
 #import "SafariViewManager.h"
 #import "RCTUtils.h"
 #import "RCTLog.h"
@@ -17,6 +18,7 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(show:(NSDictionary *)args callback:(RCTResponseSenderBlock)callback)
 {
     UIColor *tintColorString = args[@"tintColor"];
+    UIColor *barTintColorString = args[@"barTintColor"];
     BOOL fromBottom = [args[@"fromBottom"] boolValue];
 
     // Error if no url is passed
@@ -32,7 +34,19 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args callback:(RCTResponseSenderBlock)cal
     // Set tintColor if available
     if (tintColorString) {
         UIColor *tintColor = [RCTConvert UIColor:tintColorString];
-        [self.safariView.view setTintColor:tintColor];
+        if ([self.safariView respondsToSelector:@selector(setPreferredControlTintColor:)]) {
+            [self.safariView setPreferredControlTintColor:tintColor];
+        } else {
+            [self.safariView.view setTintColor:tintColor];
+        }
+    }
+
+    // Set barTintColor if available
+    if (barTintColorString) {
+        UIColor *barTintColor = [RCTConvert UIColor:barTintColorString];
+        if ([self.safariView respondsToSelector:@selector(setPreferredBarTintColor:)]) {
+            [self.safariView setPreferredBarTintColor:barTintColor];
+        }
     }
 
     // Set modal transition style

--- a/index.ios.js
+++ b/index.ios.js
@@ -19,6 +19,9 @@ export default {
     if (options && options.tintColor) {
       options.tintColor = processColor(options.tintColor);
     }
+    if (options && options.barTintColor) {
+      options.barTintColor = processColor(options.barTintColor);
+    }
 
     return new Promise((resolve, reject) => {
       NativeSafariViewManager.show(options, (error) => {


### PR DESCRIPTION
`SFSafariViewController` added [two new properties](https://developer.apple.com/reference/safariservices/sfsafariviewcontroller) to control the tint color in iOS 10, and the `.view.tintColor =` trick no longer works.

This PR adjusts the setting of the foreground tint color for iOS 10 and adds support for the new `barTintColor` for setting the background color.