### PR TITLE
Fixed Safari view not being presentable from a modal

### DIFF
--- a/SafariViewManager.m
+++ b/SafariViewManager.m
@@ -57,7 +57,7 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args callback:(RCTResponseSenderBlock)cal
     UIViewController *ctrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
 
     // Cycle through view controllers to get the view closest to the foreground
-    while (ctrl.presentedViewController) {
+    while (ctrl.presentedViewController && !ctrl.isBeingDismissed) {
         ctrl = ctrl.presentedViewController;
     }
 

--- a/SafariViewManager.m
+++ b/SafariViewManager.m
@@ -54,8 +54,14 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args callback:(RCTResponseSenderBlock)cal
         self.safariView.modalPresentationStyle = UIModalPresentationOverFullScreen;
     }
 
-    // Display the Safari View
     UIViewController *ctrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
+
+    // Cycle through view controllers to get the view closest to the foreground
+    while (ctrl.presentedViewController) {
+        ctrl = ctrl.presentedViewController;
+    }
+
+    // Display the Safari View
     [ctrl presentViewController:self.safariView animated:YES completion:nil];
 
     [self.bridge.eventDispatcher sendDeviceEventWithName:@"SafariViewOnShow" body:nil];


### PR DESCRIPTION
This is a fix for #26 
The SafariView cannot be presented when a Modal is shown, as we try to present the SafariViewController on top of a view controller that is not visible.

This change cycles through any presented view controllers, and attempts to present on top of the foremost controller

Here is a minimal react-native application that presents this problem without the change, and is subsequently fixed with the change.
I have also tested the situation without the modal (simply by commenting out the `<Modal>` lines in this example)

```jsx
import React, { Component } from 'react';
import {
  AppRegistry,
  View,
  Modal, 
  Button,
} from 'react-native';
import SafariView from 'react-native-safari-view'

export default class safaritest extends Component {
  render() {
    return (
        <View>
            <Modal>
                <Button title="Press me" onPress={()=> {
                    SafariView.isAvailable().then(()=> {
                        SafariView.show({url: 'http://github.com'})
                    })
                }} />
            </Modal>
        </View>
       );
  }
}


AppRegistry.registerComponent('safaritest', () => safaritest);
```
