### PR TITLE
replace deprecated RCTEventDispatcher

### DIFF
--- a/SafariViewManager.h
+++ b/SafariViewManager.h
@@ -1,8 +1,9 @@
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
 @import SafariServices;
 
-@interface SafariViewManager : NSObject <RCTBridgeModule, SFSafariViewControllerDelegate>
+@interface SafariViewManager : RCTEventEmitter <RCTBridgeModule, SFSafariViewControllerDelegate>
 
 @property (nonatomic) SFSafariViewController *safariView;
 

--- a/SafariViewManager.ios.js
+++ b/SafariViewManager.ios.js
@@ -11,11 +11,6 @@ import {
 const NativeSafariViewManager = NativeModules.SafariViewManager;
 const eventEmitter = new NativeEventEmitter(NativeSafariViewManager);
 
-const subscriptions = {
-  onShow: new Map(),
-  onDismiss: new Map()
-};
-
 export default {
   show(options) {
     if (options && options.tintColor) {
@@ -53,23 +48,10 @@ export default {
   },
 
   addEventListener(event, listener) {
-    if (!subscriptions[event]) {
-      console.warn(`Trying to subscribe to unknown event: "${event}"`);
-      return;
-    }
-    const subscription = eventEmitter.addListener(event, listener);
-    subscriptions[event].set(listener, subscription);
+    return eventEmitter.addListener(event, listener);
   },
 
   removeEventListener(event, listener) {
-    if (!subscriptions[event]) {
-      console.warn(`Trying to subscribe to unknown event: "${event}"`);
-      return;
-    }
-    const subscription = subscriptions[event].get(listener);
-    if (subscription) {
-      subscription.remove();
-      subscriptions[event].delete(listener);
-    }
+    eventEmitter.removeListener(event, listener);
   }
 };


### PR DESCRIPTION
~~To not break the public API I've mapped the `add/removeEventListener` to `NativeEventEmitter`'s `addListener`, instead of returning the subscription; this is a common pattern that can be found also in the React Native core (e.g.: https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/Libraries/Network/NetInfo.js#L210)~~

My previous comment was not completely valid; NativeEventEmitter also implements a `removeListener` method, so no need to keep track of the listeners ourselves. Still unclear why they use that pattern in the `NetInfo` module tho..