### PR TITLE
use namespaced events

### DIFF
--- a/SafariViewManager.ios.js
+++ b/SafariViewManager.ios.js
@@ -48,10 +48,23 @@ export default {
   },
 
   addEventListener(event, listener) {
-    return eventEmitter.addListener(event, listener);
+    if (event === 'onShow') {
+      return eventEmitter.addListener('SafariViewOnShow', listener);
+    } else if (event === 'onDismiss') {
+      return eventEmitter.addListener('SafariViewOnDismiss', listener);
+    } else {
+      console.warn(`Trying to subscribe to unknown event: ${event}`);
+      return {
+        remove: () => {}
+      };
+    }
   },
 
   removeEventListener(event, listener) {
-    eventEmitter.removeListener(event, listener);
+    if (event === 'onShow') {
+      eventEmitter.removeListener('SafariViewOnShow', listener);
+    } else if (event === 'onDismiss') {
+      eventEmitter.removeListener('SafariViewOnDismiss', listener);
+    }
   }
 };

--- a/SafariViewManager.m
+++ b/SafariViewManager.m
@@ -28,7 +28,7 @@ RCT_EXPORT_MODULE()
 
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[@"onShow", @"onDismiss"];
+    return @[@"SafariViewOnShow", @"SafariViewOnDismiss"];
 }
 
 RCT_EXPORT_METHOD(show:(NSDictionary *)args callback:(RCTResponseSenderBlock)callback)
@@ -75,7 +75,7 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args callback:(RCTResponseSenderBlock)cal
     [ctrl presentViewController:self.safariView animated:YES completion:nil];
 
     if (hasListeners) {
-        [self sendEventWithName:@"onShow" body:nil];
+        [self sendEventWithName:@"SafariViewOnShow" body:nil];
     }
 }
 
@@ -100,7 +100,7 @@ RCT_EXPORT_METHOD(dismiss)
     NSLog(@"[SafariView] SafariView dismissed.");
 
     if (hasListeners) {
-        [self sendEventWithName:@"onDismiss" body:nil];
+        [self sendEventWithName:@"SafariViewOnDismiss" body:nil];
     }
 }
 


### PR DESCRIPTION
the assumption that events are scoped when using RCTEventEmitter was incorrect, so events are now namespaced again.