### PR TITLE
Fix build with RN v0.39 and below

### DIFF
--- a/SafariViewManager.h
+++ b/SafariViewManager.h
@@ -1,5 +1,13 @@
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
+#endif
+#if __has_include(<React/RCTEventEmitter.h>)
 #import <React/RCTEventEmitter.h>
+#else
+#import "RCTEventEmitter.h"
+#endif
 
 @import SafariServices;
 

--- a/SafariViewManager.m
+++ b/SafariViewManager.m
@@ -1,8 +1,20 @@
 
 #import "SafariViewManager.h"
+#if __has_include(<React/RCTUtils.h>)
 #import <React/RCTUtils.h>
+#else
+#import "RCTUtils.h"
+#endif
+#if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
+#else
+#import "RCTLog.h"
+#endif
+#if __has_include(<React/RCTConvert.h>)
 #import <React/RCTConvert.h>
+#else
+#import "RCTConvert.h"
+#endif
 
 @implementation SafariViewManager
 {


### PR DESCRIPTION
This maintains forward compatibility

Note that this pattern of conditional header imports are used in other packages, such as [react-native-sentry](https://github.com/getsentry/react-native-sentry/blob/master/ios/RNSentry.h)