### PR TITLE
Correct version in podspec

### DIFF
--- a/react-native-safari-view.podspec
+++ b/react-native-safari-view.podspec
@@ -1,7 +1,10 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
   s.name             = "react-native-safari-view"
-  s.version          = "1.0.0"
+  s.version          = "package['version']
   s.summary          = "A React Native wrapper for Safari View Controller"
   s.requires_arc = true
   s.author       = { 'Naoufal Kadhom' => 'naoufalkadhom@gmail.com' }


### PR DESCRIPTION
Sets the version defined by the podspec according to that in `package.json`.

I don't know very much about cocoapods but might this be a fix for #82? Surely it can't be this simple though 😄 