### PR TITLE
add hidden option to allow use safari view only for read cookies

### DIFF
--- a/SafariViewManager.m
+++ b/SafariViewManager.m
@@ -77,6 +77,7 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args resolver:(RCTPromiseResolveBlock)res
     UIViewController *ctrl = RCTPresentedViewController();
     
     if (hidden) {
+        // reference from https://github.com/EddyVerbruggen/cordova-plugin-safariviewcontroller
         self.safariView.view.userInteractionEnabled = NO;
         self.safariView.view.alpha = 0.05;
         [ctrl addChildViewController:self.safariView];

--- a/SafariViewManager.m
+++ b/SafariViewManager.m
@@ -44,6 +44,7 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args resolver:(RCTPromiseResolveBlock)res
     UIColor *tintColorString = args[@"tintColor"];
     UIColor *barTintColorString = args[@"barTintColor"];
     BOOL fromBottom = [args[@"fromBottom"] boolValue];
+    BOOL hidden = [args[@"hidden"] boolValue];
 
     // Initialize the Safari View
     self.safariView = [[SFSafariViewController alloc] initWithURL:url entersReaderIfAvailable:readerMode];
@@ -75,8 +76,17 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args resolver:(RCTPromiseResolveBlock)res
     // get the view controller closest to the foreground
     UIViewController *ctrl = RCTPresentedViewController();
     
-    // Display the Safari View
-    [ctrl presentViewController:self.safariView animated:YES completion:nil];
+    if (hidden) {
+        self.safariView.view.userInteractionEnabled = NO;
+        self.safariView.view.alpha = 0.05;
+        [ctrl addChildViewController:self.safariView];
+        [ctrl.view addSubview:self.safariView.view];
+        [self.safariView didMoveToParentViewController:ctrl];
+        self.safariView.view.frame = CGRectMake(0.0, 0.0, 0.5, 0.5);        
+    } else {
+        // Display the Safari View
+        [ctrl presentViewController:self.safariView animated:YES completion:nil];
+    }
 
     if (hasListeners) {
         [self sendEventWithName:@"SafariViewOnShow" body:nil];


### PR DESCRIPTION

Sometimes we want to load the safari view controller only to read the safari cookies without showing anything on the screen.
This is useful in _deffered deep linking_ feature