### PR TITLE
Fix how URLs are converted

### DIFF
--- a/SafariViewManager.m
+++ b/SafariViewManager.m
@@ -39,7 +39,7 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args resolver:(RCTPromiseResolveBlock)res
         return;
     }
 
-    NSURL *url = [NSURL URLWithString:args[@"url"]];
+    NSURL *url = [RCTConvert NSURL:args[@"url"]];
     BOOL readerMode = [args[@"readerMode"] boolValue];
     UIColor *tintColorString = args[@"tintColor"];
     UIColor *barTintColorString = args[@"barTintColor"];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-safari-view",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A React Native wrapper for Safari View Controller",
   "main": "index",
   "scripts": {


### PR DESCRIPTION
Currently, `react-native-safari-view` does not support URLs that contain the `|` character, showing an exception that says

> Exception 'The specified URL has an unsupported scheme. Only HTTP and HTTPS URLs are supported.' was thrown while invoking show on target `SafariViewManager` with params ...

This PR fixes the issue by using `RCTConvert`