### PR TITLE
Fix header search paths for RN 0.60+

### DIFF
--- a/SafariViewManager.xcodeproj/project.pbxproj
+++ b/SafariViewManager.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;
@@ -198,9 +199,8 @@
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../React/**",
-					"$(SRCROOT)/../../node_modules/react-native/React/**",
+					"\"$(SRCROOT)/../../ios/Pods/Headers/Public/Yoga\"",
+					"\"$(SRCROOT)/../../ios/Pods/Headers/Public/React-Core\"",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -214,9 +214,8 @@
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../React/**",
-					"$(SRCROOT)/../../node_modules/react-native/React/**",
+					"\"$(SRCROOT)/../../ios/Pods/Headers/Public/Yoga\"",
+					"\"$(SRCROOT)/../../ios/Pods/Headers/Public/React-Core\"",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
Header locations changed for RN 0.60+ and they were searched from node_modules folder instead of Pods. Searching for them in node_modules/react-native wouldn't work because the folder structure was changed significantly that affected the sub imports of modules as well.